### PR TITLE
Fixed the flex on the navbar

### DIFF
--- a/style.css
+++ b/style.css
@@ -37,9 +37,13 @@ nav {
 
 }
 
+.nav-links ul {
+    display: flex;
+    justify-content: space-around;
+}
+
 .nav-links ul li {
-display: flex;
-text-decoration:none ;
+    list-style: none;
 }
 
 .nav-links a{


### PR DESCRIPTION
We use flex property in the parent element. Since they are list items, "list-style" will remove the dots, and "space-around" will separate them.